### PR TITLE
Improve Github Action CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,9 @@ on:
       - '**/LICENSE'
       - '**.md'
 
+  # Manual trigger
+  workflow_dispatch:
+
 env:
   VULKAN_SDK_VERSION: 1.3.236.0
   VAPOURSYNTH_VERSION: R61

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
       - '.gitmodules'
       - '**/LICENSE'
       - '**.md'
+
   pull_request:
     branches: [ master ]
     paths-ignore:
@@ -24,31 +25,35 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: cache-vulkansdk
-      id: cache-vulkansdk
-      uses: actions/cache@v3
-      with:
-        path: "1.2.162.0"
-        key: vulkansdk-linux-x86_64-1.2.162.0
-    - name: vulkansdk
-      if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
-      run: |
-        wget https://sdk.lunarg.com/sdk/download/1.2.162.0/linux/vulkansdk-linux-x86_64-1.2.162.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.2.162.0.tar.gz
-        tar -xf vulkansdk-linux-x86_64-1.2.162.0.tar.gz
-        rm -rf 1.2.162.0/source 1.2.162.0/samples
-        find 1.2.162.0 -type f | grep -v -E 'vulkan|glslang' | xargs rm
-    - name: configure
-      run:  |
-        wget https://github.com/vapoursynth/vapoursynth/archive/R50.tar.gz
-        tar -xzvf R50.tar.gz vapoursynth-R50/include
-        mkdir src/vapoursynth
-        mv vapoursynth-R50/include/VapourSynth.h src/vapoursynth/VapourSynth.h
-        mv vapoursynth-R50/include/VSHelper.h src/vapoursynth/VSHelper.h
-        export VULKAN_SDK=`pwd`/1.2.162.0/x86_64
-        mkdir build && cd build
-        cmake -DVAPOURSYNTH_INCLUDE_DIR=../src/vapoursynth ..
-    - name: build
-      run: cmake --build build -j 2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: cache-vulkansdk
+        id: cache-vulkansdk
+        uses: actions/cache@v3
+        with:
+          path: "1.2.162.0"
+          key: vulkansdk-linux-x86_64-1.2.162.0
+
+      - name: vulkansdk
+        if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
+        run: |
+          wget https://sdk.lunarg.com/sdk/download/1.2.162.0/linux/vulkansdk-linux-x86_64-1.2.162.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.2.162.0.tar.gz
+          tar -xf vulkansdk-linux-x86_64-1.2.162.0.tar.gz
+          rm -rf 1.2.162.0/source 1.2.162.0/samples
+          find 1.2.162.0 -type f | grep -v -E 'vulkan|glslang' | xargs rm
+
+      - name: configure
+        run:  |
+          wget https://github.com/vapoursynth/vapoursynth/archive/R50.tar.gz
+          tar -xzvf R50.tar.gz vapoursynth-R50/include
+          mkdir src/vapoursynth
+          mv vapoursynth-R50/include/VapourSynth.h src/vapoursynth/VapourSynth.h
+          mv vapoursynth-R50/include/VSHelper.h src/vapoursynth/VSHelper.h
+          export VULKAN_SDK=`pwd`/1.2.162.0/x86_64
+          mkdir build && cd build
+          cmake -DVAPOURSYNTH_INCLUDE_DIR=../src/vapoursynth ..
+
+      - name: build
+        run: cmake --build build -j 2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,15 @@ jobs:
       - name: build
         run: cmake --build build -j 2
 
+      - name: strip
+        run: strip build/libsrmdnv.so
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-vapoursynth-srmd-ncnn-vulkan
+          path: build/libsrmdnv.so
+
   build-windows:
 
     runs-on: windows-latest
@@ -102,3 +111,12 @@ jobs:
 
       - name: build
         run: cmake --build build -j 2
+
+      - name: strip
+        run: strip build/Debug/srmdnv.dll
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-vapoursynth-srmd-ncnn-vulkan
+          path: build/Debug/srmdnv.dll

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: cache-vulkansdk
       id: cache-vulkansdk
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: "1.2.162.0"
         key: vulkansdk-linux-x86_64-1.2.162.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ env:
   CMAKE_BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -59,6 +59,46 @@ jobs:
           export VULKAN_SDK=$(pwd)/${{env.VULKAN_SDK_VERSION}}/x86_64
           mkdir build && cd build
           cmake -DVAPOURSYNTH_INCLUDE_DIR=../src/vapoursynth ..
+
+      - name: build
+        run: cmake --build build -j 2
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: cache-vulkansdk
+        id: cache-vulkansdk
+        uses: actions/cache@v3
+        with:
+          path: ${{env.VULKAN_SDK_VERSION}}
+          key: vulkansdk-windows-${{env.VULKAN_SDK_VERSION}}
+
+      - name: vulkansdk
+        if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
+        env:
+          VULKAN_SDK: ${{env.GITHUB_WORKSPACE}}/${{env.VULKAN_SDK_VERSION}}
+        run: |
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/windows/VulkanSDK-${{env.VULKAN_SDK_VERSION}}-Installer.exe?Human=true -OutFile VulkanSDK-${{env.VULKAN_SDK_VERSION}}-Installer.exe
+          7z x -aoa ./VulkanSDK-${{env.VULKAN_SDK_VERSION}}-Installer.exe -oVulkanSDK
+          Remove-Item .\VulkanSDK\Demos -Recurse
+          mv VulkanSDK ${{env.VULKAN_SDK_VERSION}}
+
+      - name: configure
+        run:  |
+          curl -s -L https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz -o ${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
+          mkdir "C:/Program Files/VapourSynth/sdk/include/vapoursynth"
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VapourSynth.h"
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VSHelper.h"
+          $env:VULKAN_SDK="$(pwd)/${{env.VULKAN_SDK_VERSION}}"
+          mkdir build && cd build
+          cmake ..
 
       - name: build
         run: cmake --build build -j 2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,11 @@ on:
       - '**/LICENSE'
       - '**.md'
 
+env:
+  VULKAN_SDK_VERSION: 1.2.162.0
+  VAPOURSYNTH_VERSION: R50
+  CMAKE_BUILD_TYPE: Release
+
 jobs:
   build:
 
@@ -33,25 +38,25 @@ jobs:
         id: cache-vulkansdk
         uses: actions/cache@v3
         with:
-          path: "1.2.162.0"
-          key: vulkansdk-linux-x86_64-1.2.162.0
+          path: ${{env.VULKAN_SDK_VERSION}}
+          key: vulkansdk-linux-${{env.VULKAN_SDK_VERSION}}
 
       - name: vulkansdk
         if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
         run: |
-          wget https://sdk.lunarg.com/sdk/download/1.2.162.0/linux/vulkansdk-linux-x86_64-1.2.162.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.2.162.0.tar.gz
-          tar -xf vulkansdk-linux-x86_64-1.2.162.0.tar.gz
-          rm -rf 1.2.162.0/source 1.2.162.0/samples
-          find 1.2.162.0 -type f | grep -v -E 'vulkan|glslang' | xargs rm
+          wget https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/linux/vulkansdk-linux-x86_64-${{env.VULKAN_SDK_VERSION}}.tar.gz?Human=true -O vulkansdk-linux-x86_64-${{env.VULKAN_SDK_VERSION}}.tar.gz
+          tar -xf vulkansdk-linux-x86_64-${{env.VULKAN_SDK_VERSION}}.tar.gz
+          rm -rf ${{env.VULKAN_SDK_VERSION}}/source ${{env.VULKAN_SDK_VERSION}}/samples
+          find ${{env.VULKAN_SDK_VERSION}} -type f | grep -v -E 'vulkan|glslang' | xargs rm
 
       - name: configure
         run:  |
-          wget https://github.com/vapoursynth/vapoursynth/archive/R50.tar.gz
-          tar -xzvf R50.tar.gz vapoursynth-R50/include
+          wget https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
           mkdir src/vapoursynth
-          mv vapoursynth-R50/include/VapourSynth.h src/vapoursynth/VapourSynth.h
-          mv vapoursynth-R50/include/VSHelper.h src/vapoursynth/VSHelper.h
-          export VULKAN_SDK=`pwd`/1.2.162.0/x86_64
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h src/vapoursynth/VapourSynth.h
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h src/vapoursynth/VSHelper.h
+          export VULKAN_SDK=$(pwd)/${{env.VULKAN_SDK_VERSION}}/x86_64
           mkdir build && cd build
           cmake -DVAPOURSYNTH_INCLUDE_DIR=../src/vapoursynth ..
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,14 +20,14 @@ on:
       - '**.md'
 
 env:
-  VULKAN_SDK_VERSION: 1.2.162.0
-  VAPOURSYNTH_VERSION: R50
+  VULKAN_SDK_VERSION: 1.3.236.0
+  VAPOURSYNTH_VERSION: R61
   CMAKE_BUILD_TYPE: Release
 
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ cmake ..
 cmake --build .
 ```
 
+### Windows and Linux using Github Actions
+
+1.[Fork this repository](https://github.com/Kiyamou/VapourSynth-SRMD-ncnn-Vulkan/fork).
+
+2.Enable Github Actions on your fork: **Settings** tab -> **Actions** -> **General** -> **Allow all actions and reusable workflows** -> **Save** button.
+
+3.Edit (if necessary) the file `.github/workflows/CI.yml` on your fork modifying the environment variables Vulkan SDK and/or VapourSynth versions:
+
+```
+env:
+  VULKAN_SDK_VERSION: <SET_YOUR_VERSION>
+  VAPOURSYNTH_VERSION: <SET_YOUR_VERSION>
+```
+
+4.Go to the GitHub **Actions** tab on your fork, select **CI** workflow and press the **Run workflow** button (if you modified the `.github/workflows/CI.yml` file, a workflow will be already running and no need to run a new one).
+
+When the workflow is completed you will be able to download the artifacts generated (Windows and Linux versions) from the run.
+
+## Download Nightly Builds
+
+**GitHub Actions Artifacts ONLY can be downloaded by GitHub logged users.**
+
+Nightly builds are built automatically by GitHub Actions (GitHub's integrated CI/CD tool) every time a new commit is pushed to the _master_ branch or a pull request is created.
+
+To download the latest nightly build, go to the GitHub [Actions](https://github.com/Kiyamou/VapourSynth-SRMD-ncnn-Vulkan/actions/workflows/CI.yml) tab, enter the last run of workflow **CI**, and download the artifacts generated (Windows and Linux versions) from the run.
+
 ## Reference Code
 
 * srmd-ncnn-vulkan: https://github.com/nihui/srmd-ncnn-vulkan


### PR DESCRIPTION
With these changes, GitHub users can compile the latest version using GitHub Actions without install Vulkan SDK, VapourSynth and compilation tools on their computers, getting Linux and Windows libraries with the Vulkan SDK and VapourSynth versions of their choice (README is updated with instructions), so it's very easy test the code with different Vulkan SDK and VapourSynth versions.

* No need to compile if text files are changed
* Update actions to avoid warnings about deprecated actions
* Update to Ubuntu latest
* Update to Vulkan SDK 1.3.236.0 and VapourSynth R61 using environment variables
* Add Windows build (CI.yml was reformatted to tabulate Linux and Windows steps)
* Upload compiled Linux and Windows stripped libraries
* Add manual trigger to test compilation with other branches
* Add GitHub Actions instructions in README